### PR TITLE
:construction_worker:Limit CI build job to 30 min

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         python-version: ["3.9"]
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This is for safety, we can increase it later.