### PR TITLE
♻️ Proper treatment of jupyter magic commands

### DIFF
--- a/nbproject/_dependencies.py
+++ b/nbproject/_dependencies.py
@@ -57,7 +57,7 @@ def notebook_deps(content: Union[NotebookNode, dict, list], pin_versions: bool =
         if "import" not in cell_source:
             continue
         else:
-            # quck hack to ignore jupyter magics
+            # quick hack to ignore jupyter magics
             if "%" in cell_source:
                 if magics_re is None:
                     magics_re = re.compile(r"^( *)%{1,2}\w+ *", flags=re.MULTILINE)


### PR DESCRIPTION
If a magic command is in the code, ast throws an error. This removes magic commands before feeding the code to ast.