### PR TITLE
🚸 Remove execution of cells after metadata write

### DIFF
--- a/nbproject/dev/_jupyter_lab_commands.py
+++ b/nbproject/dev/_jupyter_lab_commands.py
@@ -32,7 +32,10 @@ def _reload_and_restart_notebook():
         _app = JupyterFrontEnd()
 
     _app.commands.execute("docmanager:reload")  # reload notebook from disk
-    _app.commands.execute("notebook:restart-and-run-to-selected")
+    _app.commands.execute("kernelmenu:restart")
+
+    # the below was useful for init, but is not viable for publish()
+    # _app.commands.execute("notebook:restart-and-run-to-selected")
     # It'd be nice to execute more cells here, but that's impossible
     # as the kernel is dead at this point
     #


### PR DESCRIPTION
@Zethson experienced that notebooks cells were actually executed after publish().

This should evidently not be the case. The original rationale for the former line of code was to display the header automatically after init. But that doesn't work for me anyway, and it's also not a big deal if one needs to manually run the first cell after init.