### PR TITLE
🚸 Raise error upon publishing notebook without title

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -7,7 +7,7 @@ Look up guides for edges cases, warnings, and errors.
 {doc}`example-project-uninitialized/index`.
 
 - {doc}`example-after-init-set-filename` shows how to manually pass a notebook filename.
-- {doc}`example-after-init-without-title` shows how a lack of title leads to a warning.
+- {doc}`publish-without-title` shows how a lack of title leads to a warning.
 - {doc}`publish-without-saving`
 - {doc}`publish-not-last-cell`
 - {doc}`publish-wrapper`
@@ -20,7 +20,7 @@ Look up guides for edges cases, warnings, and errors.
 example-project/index
 example-project-uninitialized/index
 example-after-init-set-filename
-example-after-init-without-title
+publish-without-title
 publish-without-saving
 publish-not-last-cell
 publish-wrapper

--- a/docs/guides/publish-without-title.ipynb
+++ b/docs/guides/publish-without-title.ipynb
@@ -5,7 +5,7 @@
    "id": "37b372a5-fae0-4177-986f-0adeea86158f",
    "metadata": {},
    "source": [
-    "This notebooks demonstrates how a warning is raised when there is **no** title in the first cell."
+    "This notebooks shows how a warning and an error is raised when there is no title in the first cell."
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "411d20ca-f637-4d3f-9047-1b5782b1d7ea",
    "metadata": {},
    "source": [
-    "# Example after init without title"
+    "# Try to publish without title"
    ]
   },
   {
@@ -23,19 +23,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nbproject import header\n",
+    "from nbproject import header, meta, publish\n",
+    "import pytest\n",
     "\n",
     "header()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ce9c305f-a65f-4e71-86e7-eab4572dc8e1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from nbproject import meta"
    ]
   },
   {
@@ -45,7 +36,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "meta.live.title"
+    "meta.live.title  # returns None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9665051-9d08-4f52-aa8e-7ffe1e5514e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This would print: Error: No title! Please update & save your notebook so that it has a markdown cell with the title: # My title\n",
+    "with pytest.raises(RuntimeError):\n",
+    "    publish(i_confirm_i_saved=True, integrity=False)"
    ]
   }
  ],
@@ -65,7 +68,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   },
   "nbproject": {
    "dependency": {

--- a/nbproject/_meta.py
+++ b/nbproject/_meta.py
@@ -12,18 +12,11 @@ from .dev._notebook import Notebook, read_notebook
 
 def get_title(nb: Notebook) -> Optional[str]:
     """Get title of the notebook."""
-    title_error = (
-        "Warning: No title! Please update & save your notebook so that it has a"
-        " markdown cell with the title: # My title"
-    )
-
     if nb.cells[0]["cell_type"] != "markdown":
-        logger.info(title_error)
         title = None
     else:
         title = nb.cells[0]["source"][0]
         if not title.startswith("# "):
-            logger.info(title_error)
             title = None
         else:
             title = title.lstrip("#").strip(" .")

--- a/nbproject/_publish.py
+++ b/nbproject/_publish.py
@@ -32,9 +32,10 @@ def publish(
 
     This function should be called in the last code cell of the notebook!
 
-    1. Sets the version.
-    2. Stores dependencies.
-    3. Checks integrity, i.e., whether notebook cells were executed consecutively.
+    1. Checks that the notebook has a title.
+    2. Sets the version.
+    3. Stores dependencies.
+    4. Checks integrity, i.e., whether notebook cells were executed consecutively.
 
     Returns the integrity check result.
 
@@ -54,6 +55,15 @@ def publish(
         calling_statement = kwargs["calling_statement"]
     else:
         calling_statement = "publish("
+
+    notebook_title = meta.live.title
+    title_error = (
+        "Error: No title! Please update & save your notebook so that it has a"
+        " markdown cell with the title: # My title"
+    )
+
+    if notebook_title is None:
+        raise RuntimeError(title_error)
 
     if meta._env == "lab":
         _save_notebook()


### PR DESCRIPTION
As discussed before, it shouldn't be possible to publish a notebook without title:

- https://github.com/laminlabs/nbproject/issues/142

This new implementation makes the warning in `meta.live.title` superfluous.