### PR TITLE
💄 Simplify dependency display & make version the 2nd field to be displayed

### DIFF
--- a/nbproject/dev/_metadata_display.py
+++ b/nbproject/dev/_metadata_display.py
@@ -99,14 +99,13 @@ def table_metadata(
 
     table = []
     table.append(["id", dm.id()])
+    version = dm.version()
+    table.append(["version", version])
     table.append(["time_init", dm.time_init()])
 
     if time_run is None:
         time_run = datetime.now(timezone.utc)
     table.append(["time_run", dm.time_run(time_run)])
-
-    version = dm.version()
-    table.append(["version", version])
 
     if version != "draft":
         logger.disable("nbproject.dev._consecutiveness")


### PR DESCRIPTION
If stored and live dependencies match perfectly, there is no need to display them twice.

The purpose of the "side-by-side-display" is meant to alert the user of package changes. If there are none, there is a lot of visual noise conveying no information.

Re version 2nd: LaminDB currently converges to referencing entities with an `(id, v)` tuple, where v is the version. `version` is always the second field for every entity. It's nice if notebooks are no exception.