### PR TITLE
:sparkles: Add `author` field and a few fixes

### DIFF
--- a/docs/faq/header-author-field.ipynb
+++ b/docs/faq/header-author-field.ipynb
@@ -23,7 +23,7 @@
    "id": "8b390071",
    "metadata": {},
    "source": [
-    "If a `lamindb` user account was [set up](https://lamin.ai/docs/lndb-setup/guide/setup-user), then initialized headers of notebooks will have an author field consisting of `user_handle` and `user_id` in brackets. Here they are the same."
+    "If a `lamindb` user account was [set up](https://lamin.ai/docs/db/guide/get-started), then initialized headers of notebooks will have an author field consisting of `user_handle` and `user_id` in brackets. Here they are the same."
    ]
   },
   {

--- a/docs/faq/header-author-field.ipynb
+++ b/docs/faq/header-author-field.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1bead9ef",
+   "metadata": {},
+   "source": [
+    "# Author field in `header` and `meta.store`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a2ddf26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nbproject import header, meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b390071",
+   "metadata": {},
+   "source": [
+    "If a `lamindb` user account was [set up](https://lamin.ai/docs/lndb-setup/guide/setup-user), then initialized headers of notebooks will have an author field consisting of `user_handle` and `user_id` in brackets. Here they are the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d25474c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bc94a37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert meta.store.user_handle == \"qTQ5q0ar\"\n",
+    "assert meta.store.user_id == \"qTQ5q0ar\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "nbproject": {
+   "id": "Zv1wV7oM9ztH",
+   "parent": null,
+   "pypackage": null,
+   "time_init": "2022-10-09T15:08:04.997800+00:00",
+   "user_handle": "qTQ5q0ar",
+   "user_id": "qTQ5q0ar",
+   "version": "draft"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/faq/header-author-field.ipynb
+++ b/docs/faq/header-author-field.ipynb
@@ -39,6 +39,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "031af731",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4bc94a37",
    "metadata": {},
    "outputs": [],

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -22,6 +22,7 @@ Edges cases, warnings, and errors:
 - {doc}`not-initialized`
 - {doc}`internal-functions`
 - {doc}`set-env-via-environment-var`
+- {doc}`header-author-field`
 
 ```{toctree}
 :maxdepth: 1
@@ -44,4 +45,5 @@ trigger-exit-upon-init
 not-initialized
 internal-functions
 set-env-via-environment-var
+header-author-field
 ```

--- a/nbproject/_meta.py
+++ b/nbproject/_meta.py
@@ -55,7 +55,10 @@ class meta:
         cls._env = env
         cls._time_run = _time_run
 
-        nb_meta = read_notebook(cls._filepath).metadata
+        if cls._filepath is not None:
+            nb_meta = read_notebook(cls._filepath).metadata
+        else:
+            nb_meta = None
 
         if nb_meta is not None and "nbproject" in nb_meta:
             meta_container = MetaContainer(**nb_meta["nbproject"])

--- a/nbproject/_meta.py
+++ b/nbproject/_meta.py
@@ -16,7 +16,17 @@ class classproperty(object):
         return self.fget(owner_cls)
 
 
-class meta:
+# https://stackoverflow.com/questions/8955754/can-i-define-a-repr-for-a-class-rather-than-an-instance
+class MetaRepr(type):
+    def __repr__(cls):
+        return (
+            "Metadata object with .live and .store metadata fields:\n"
+            f"  .store: {cls.store}\n"
+            f"  .live: {cls.live}"
+        )
+
+
+class meta(metaclass=MetaRepr):
     """Access `meta.store` and `meta.live`.
 
     - `meta.store` - nbproject metadata of the ipynb file, see
@@ -89,10 +99,3 @@ class meta:
         if cls._env is None:
             cls._init_meta()
         return cls._env
-
-    def __repr__(self):
-        return (
-            "Metadata object with .live and .store metadata fields:\n"
-            f"  .store: {self.store}\n"
-            f"  .live: {self.live}"
-        )

--- a/nbproject/_publish.py
+++ b/nbproject/_publish.py
@@ -62,6 +62,9 @@ def run_checks_for_publish(
 def finalize_publish(*, calling_statement: str, version: Optional[str] = None):
     meta.store.version = set_version(version)
     meta.store.pypackage = meta.live.pypackage
+    meta.store.user_handle = meta.live.user_handle
+    meta.store.user_id = meta.live.user_id
+    meta.store.user_name = meta.live.user_name
     logger.info(
         f"Set notebook version to {colors.bold(meta.store.version)} & wrote pypackages."
     )

--- a/nbproject/dev/_initialize.py
+++ b/nbproject/dev/_initialize.py
@@ -3,6 +3,7 @@ import string
 from datetime import datetime, timezone
 from typing import List, Optional, Union
 
+from ._lamin_communicate import lamin_user_name, lamin_user_settings
 from ._meta_store import MetaContainer
 from ._notebook import Notebook
 
@@ -40,14 +41,13 @@ def initialize_metadata(
     if parent is not None:
         meta.parent = parent
 
-    try:
-        from lndb_setup import settings
+    user_handle, user_id = lamin_user_settings()
+    if user_handle is None and user_id is None:
+        meta.user_handle = user_handle
+        meta.user_id = user_id
 
-        user_handle, user_id = settings.user.handle, settings.user.id
-        if user_handle is not None and user_id is not None:
-            meta.user_handle = user_handle
-            meta.user_id = user_id
-    except ModuleNotFoundError:
-        pass
+        user_name = lamin_user_name(user_id)
+        if user_name is not None:
+            meta.user_name = user_name
 
     return meta

--- a/nbproject/dev/_initialize.py
+++ b/nbproject/dev/_initialize.py
@@ -42,7 +42,7 @@ def initialize_metadata(
         meta.parent = parent
 
     user_handle, user_id = lamin_user_settings()
-    if user_handle is None and user_id is None:
+    if user_handle is not None and user_id is not None:
         meta.user_handle = user_handle
         meta.user_id = user_id
 

--- a/nbproject/dev/_initialize.py
+++ b/nbproject/dev/_initialize.py
@@ -40,4 +40,14 @@ def initialize_metadata(
     if parent is not None:
         meta.parent = parent
 
+    try:
+        from lndb_setup import settings
+
+        user_handle, user_id = settings.user.handle, settings.user.id
+        if user_handle is not None and user_id is not None:
+            meta.user_handle = user_handle
+            meta.user_id = user_id
+    except ModuleNotFoundError:
+        pass
+
     return meta

--- a/nbproject/dev/_lamin_communicate.py
+++ b/nbproject/dev/_lamin_communicate.py
@@ -1,0 +1,7 @@
+def lamin_user_settings():
+    try:
+        from lndb_setup import settings
+
+        return settings.user.handle, settings.user.id
+    except ModuleNotFoundError:
+        return None, None

--- a/nbproject/dev/_lamin_communicate.py
+++ b/nbproject/dev/_lamin_communicate.py
@@ -1,7 +1,33 @@
+from typing import Optional
+
+
 def lamin_user_settings():
     try:
         from lndb_setup import settings
 
         return settings.user.handle, settings.user.id
-    except ModuleNotFoundError:
+    except ImportError:
         return None, None
+
+
+def lamin_user_name(user_id: Optional[str] = None):
+    try:
+        import lndb_setup
+        import lnschema_core as schema_core
+        import sqlmodel as sqm
+
+        settings = lndb_setup.settings
+
+        if settings.instance.name is not None:
+            if user_id is None:
+                current_user_id = settings.user.id
+                if current_user_id is None:
+                    return None
+                else:
+                    user_id = current_user_id
+
+            with sqm.Session(settings.instance.db_engine()) as session:
+                user = session.get(schema_core.user, user_id)
+                return getattr(user, "name", None)
+    except ImportError:
+        return None

--- a/nbproject/dev/_meta_live.py
+++ b/nbproject/dev/_meta_live.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 from .._logger import logger
 from ._consecutiveness import check_consecutiveness
 from ._jupyter_lab_commands import _save_notebook
+from ._lamin_communicate import lamin_user_name, lamin_user_settings
 from ._notebook import Notebook, read_notebook
 from ._pypackage import infer_pypackages
 
@@ -94,6 +95,21 @@ class MetaLive:
     def time_passed(self):
         """Number of seconds elapsed from `time_run`."""
         return (datetime.now(timezone.utc) - self._time_run).total_seconds()
+
+    @property
+    def user_handle(self):
+        """User handle from lamindb."""
+        return lamin_user_settings()[0]
+
+    @property
+    def user_id(self):
+        """User ID from lamindb."""
+        return lamin_user_settings()[1]
+
+    @property
+    def user_name(self):
+        """User name from lamindb."""
+        return lamin_user_name()
 
     def __repr__(self):
         return "Fields: " + " ".join([key for key in dir(self) if key[0] != "_"])

--- a/nbproject/dev/_meta_store.py
+++ b/nbproject/dev/_meta_store.py
@@ -54,6 +54,10 @@ class MetaContainer(BaseModel):
     """Dictionary of notebook pypackages and their versions."""
     parent: Union[str, List[str], None] = None
     """One or more nbproject ids of direct ancestors in a notebook pipeline."""
+    user_handle: Optional[str] = None
+    """User handle from lamindb."""
+    user_id: Optional[str] = None
+    """User ID from lamindb."""
 
     class Config:  # noqa
         extra = Extra.allow

--- a/nbproject/dev/_meta_store.py
+++ b/nbproject/dev/_meta_store.py
@@ -58,6 +58,8 @@ class MetaContainer(BaseModel):
     """User handle from lamindb."""
     user_id: Optional[str] = None
     """User ID from lamindb."""
+    user_name: Optional[str] = None
+    """User name from lamindb."""
 
     class Config:  # noqa
         extra = Extra.allow

--- a/nbproject/dev/_metadata_display.py
+++ b/nbproject/dev/_metadata_display.py
@@ -108,6 +108,25 @@ class DisplayMeta:
         user_handle = self.metadata.get("user_handle", None)
         user_id = self.metadata.get("user_id", None)
 
+        user_name = None
+        # the whole try block is about retrieving a user name from a local database
+        try:
+            import lndb_setup
+            import lnschema_core as schema_core
+            import sqlmodel as sqm
+
+            settings = lndb_setup.settings
+
+            if settings.instance.name is not None and settings.user.id is not None:
+                with sqm.Session(settings.instance.db_engine()) as session:
+                    user = session.get(schema_core.user, user_id)
+                if user.name is None:
+                    user_name = user.name
+        except ImportError:
+            pass
+
+        if user_name is not None and user_handle is not None:
+            return f"{user_name} ({user_handle})"
         if user_handle is not None and user_id is not None:
             return f"{user_handle} ({user_id})"
         else:

--- a/nbproject/dev/_metadata_display.py
+++ b/nbproject/dev/_metadata_display.py
@@ -104,6 +104,15 @@ class DisplayMeta:
             deps_list.sort()
             return deps_list
 
+    def author(self):
+        user_handle = self.metadata.get("user_handle", None)
+        user_id = self.metadata.get("user_id", None)
+
+        if user_handle is not None and user_id is not None:
+            return f"{user_handle} ({user_id})"
+        else:
+            return None
+
 
 def table_metadata(
     metadata: Mapping, notebook: Notebook, time_run: Optional[datetime] = None
@@ -114,6 +123,11 @@ def table_metadata(
     table.append(["id", dm.id()])
     version = dm.version()
     table.append(["version", version])
+
+    author = dm.author()
+    if author is not None:
+        table.append(["author", author])
+
     table.append(["time_init", dm.time_init()])
 
     if time_run is None:

--- a/nbproject/dev/_metadata_display.py
+++ b/nbproject/dev/_metadata_display.py
@@ -131,13 +131,14 @@ def table_metadata(
     dm = DisplayMeta(metadata)
 
     table = []
-    table.append(["id", dm.id()])
-    version = dm.version()
-    table.append(["version", version])
 
     author = dm.author()
     if author is not None:
         table.append(["author", author])
+
+    table.append(["id", dm.id()])
+    version = dm.version()
+    table.append(["version", version])
 
     table.append(["time_init", dm.time_init()])
 


### PR DESCRIPTION
- Adds the `author` field as discussed. It is added on initialization of a notebook if `lndb_setup` can be imported and has user settings.
- Fixes access to `nbproject.meta.store` not from a notebook, i.e. get uninitialized metadata instead of throwing an error.
- Fix `__repr__` of `nbproject.meta`, it wasn't working properly because `meta` was changed to static class some time ago.