### PR TITLE
🚸 Support inferring notebook path when executed through nbconvert

### DIFF
--- a/docs/guide/received.ipynb
+++ b/docs/guide/received.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The header now makes package verion mismatches evident. "
+    "The header now makes package version mismatches evident. "
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "nbproject_test >= 0.4.5",
     "laminci",
     "ipylab",
+    "nbconvert",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyyaml",
     "packaging",
     "orjson",
+    "psutil",
     "importlib-metadata",
     "stdlib_list; python_version < '3.10'",
     "lamin_utils>=0.13.2",

--- a/tests/for-nbconvert.ipynb
+++ b/tests/for-nbconvert.ipynb
@@ -1,0 +1,22 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nbproject.dev._jupyter_communicate import notebook_path\n",
+    "\n",
+    "assert notebook_path() is not None, \"Cannot infer notebook path.\""
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_nbconvert.py
+++ b/tests/test_nbconvert.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_running_via_nbconvert():
+    result = subprocess.run(
+        "jupyter nbconvert --to notebook --execute ./tests/for-nbconvert.ipynb",
+        shell=True,
+        capture_output=True,
+    )
+    print(result.stdout.decode())
+    print(result.stderr.decode())
+    assert result.returncode == 0


### PR DESCRIPTION
Enables the following:
```
jupyter nbconvert --to notebook --execute test-nbconvert.ipynb
```