### PR TITLE
🚸 Error for nbconvert if `--inplace` is not passed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.13"]
 
     steps:
       - name: Checkout main
@@ -61,7 +61,7 @@ jobs:
       - run: nox -s build
 
       - name: Codecov
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/nbproject/dev/_jupyter_communicate.py
+++ b/nbproject/dev/_jupyter_communicate.py
@@ -121,6 +121,9 @@ def find_nb_path_via_parent_process():
             if arg.endswith(".ipynb"):
                 potential_path = arg  # Store the last one found
 
+        if is_nbconvert_call and "--inplace" not in cmdline:
+            raise ValueError("Please execute 'nbconvert' with option '--inplace'.")
+
         if is_nbconvert_call and potential_path:
             # We found something that looks like an nbconvert call and an ipynb file
             # The path might be relative to the parent process's CWD.
@@ -169,6 +172,8 @@ def find_nb_path_via_parent_process():
     except psutil.Error as e:
         logger.warning(f"psutil error: {e}")
         return None
+    except ValueError as ve:  # Explicitly catch and re-raise the intended error
+        raise ve
     except Exception as e:
         logger.warning(f"Unexpected error during psutil check: {e}")
         return None

--- a/nbproject/dev/_jupyter_communicate.py
+++ b/nbproject/dev/_jupyter_communicate.py
@@ -122,7 +122,9 @@ def find_nb_path_via_parent_process():
                 potential_path = arg  # Store the last one found
 
         if is_nbconvert_call and "--inplace" not in cmdline:
-            raise ValueError("Please execute 'nbconvert' with option '--inplace'.")
+            raise ValueError(
+                "Please execute notebook 'nbconvert' by passing option '--inplace'."
+            )
 
         if is_nbconvert_call and potential_path:
             # We found something that looks like an nbconvert call and an ipynb file

--- a/nbproject/dev/_jupyter_communicate.py
+++ b/nbproject/dev/_jupyter_communicate.py
@@ -105,21 +105,33 @@ def find_nb_path_via_parent_process():
                 # or a subcommand (e.g. ['jupyter', 'nbconvert', ...])
                 # or a module call (e.g. ['python', '-m', 'nbconvert', ...])
                 base_arg = os.path.basename(arg).lower()  # noqa: PTH119
-                if (
-                    "jupyter-nbconvert" in base_arg
-                    or arg == "nbconvert"
-                    or (
-                        cmdline[i - 1].endswith("python")
-                        and arg == "-m"
-                        and cmdline[i + 1] == "nbconvert"
-                    )
-                ):
+                # Refined check for context (ensure imports like os are present)
+                is_direct_call = ("jupyter-nbconvert" in base_arg and i == 0) or (
+                    "nbconvert" in base_arg and i == 0
+                )
+                # Handle potential IndexError for cmdline[i-1], cmdline[i+1]
+                is_jupyter_subcommand = (
+                    i > 0
+                    and arg.lower() == "nbconvert"
+                    and "jupyter" in os.path.basename(cmdline[i - 1]).lower()  # noqa: PTH119
+                )
+                is_python_m_call = (
+                    i > 1
+                    and arg.lower() == "nbconvert"
+                    and cmdline[i - 1] == "-m"
+                    and "python" in os.path.basename(cmdline[i - 2]).lower()  # noqa: PTH119
+                )
+
+                if is_direct_call or is_jupyter_subcommand or is_python_m_call:
                     is_nbconvert_call = True
 
             # Find the argument ending in .ipynb AFTER 'nbconvert' is likely found
             # Or just find the last argument ending in .ipynb as a guess
             if arg.endswith(".ipynb"):
                 potential_path = arg  # Store the last one found
+
+        if is_nbconvert_call and "--inplace" not in cmdline:
+            raise ValueError("Please execute 'nbconvert' with option '--inplace'.")
 
         if is_nbconvert_call and potential_path:
             # We found something that looks like an nbconvert call and an ipynb file
@@ -129,6 +141,7 @@ def find_nb_path_via_parent_process():
             try:
                 # Get parent's CWD
                 parent_cwd = parent_process.cwd()
+                # Ensure Path is imported from pathlib
                 resolved_path = Path(parent_cwd) / Path(potential_path)
                 if resolved_path.is_file():
                     logger.info(f"psutil: Found potential path: {resolved_path}")
@@ -158,8 +171,11 @@ def find_nb_path_via_parent_process():
                 logger.warning(f"psutil: Error resolving path '{potential_path}': {e}")
                 return None
 
+        # This warning might now be less relevant if error is raised above,
+        # but kept as per "no other changes" request for the case where nbconvert
+        # wasn't detected at all.
         logger.warning(
-            "psutil: Could not reliably identify notebook path from parent cmdline."
+            "psutil: Could not reliably identify notebook path from parent cmdline OR requirements not met."
         )
         return None
 
@@ -169,6 +185,8 @@ def find_nb_path_via_parent_process():
     except psutil.Error as e:
         logger.warning(f"psutil error: {e}")
         return None
+    except ValueError as ve:  # Explicitly catch and re-raise the intended error
+        raise ve
     except Exception as e:
         logger.warning(f"Unexpected error during psutil check: {e}")
         return None

--- a/tests/test_nbconvert.py
+++ b/tests/test_nbconvert.py
@@ -10,16 +10,4 @@ def test_running_via_nbconvert():
     )
     print(result.stdout.decode())
     print(result.stderr.decode())
-    assert result.returncode == 1
-    assert (
-        "Please execute 'nbconvert' with option '--inplace'." in result.stderr.decode()
-    )
-
-    result = subprocess.run(
-        "jupyter nbconvert --to notebook --inplace --execute ./tests/for-nbconvert.ipynb",
-        shell=True,
-        capture_output=True,
-    )
-    print(result.stdout.decode())
-    print(result.stderr.decode())
-    assert result.returncode == 1
+    assert result.returncode == 0

--- a/tests/test_nbconvert.py
+++ b/tests/test_nbconvert.py
@@ -10,4 +10,16 @@ def test_running_via_nbconvert():
     )
     print(result.stdout.decode())
     print(result.stderr.decode())
-    assert result.returncode == 0
+    assert result.returncode == 1
+    assert (
+        "Please execute 'nbconvert' with option '--inplace'." in result.stderr.decode()
+    )
+
+    result = subprocess.run(
+        "jupyter nbconvert --to notebook --inplace --execute ./tests/for-nbconvert.ipynb",
+        shell=True,
+        capture_output=True,
+    )
+    print(result.stdout.decode())
+    print(result.stderr.decode())
+    assert result.returncode == 1

--- a/tests/test_nbconvert.py
+++ b/tests/test_nbconvert.py
@@ -8,11 +8,10 @@ def test_running_via_nbconvert():
         shell=True,
         capture_output=True,
     )
-    print(result.stdout.decode())
-    print(result.stderr.decode())
     assert result.returncode == 1
     assert (
-        "Please execute 'nbconvert' with option '--inplace'." in result.stderr.decode()
+        "Please execute notebook 'nbconvert' by passing option '--inplace'."
+        in result.stderr.decode()
     )
 
     result = subprocess.run(
@@ -22,4 +21,4 @@ def test_running_via_nbconvert():
     )
     print(result.stdout.decode())
     print(result.stderr.decode())
-    assert result.returncode == 1
+    assert result.returncode == 0


### PR DESCRIPTION
Because of how we map run reports based on the notebook file name in some cases, it's safer to require `--inplace` for `nbconvert` execution.